### PR TITLE
Added `/` due to redirection issues

### DIFF
--- a/sample.config.py
+++ b/sample.config.py
@@ -37,7 +37,7 @@ menu_icon: dict[str, Optional[str]] = {
 
 """Server Config"""
 # needed for loading leaderboards
-# you can find your's here https://old.ppy.sh/p/api
+# you can find your's here https://old.ppy.sh/p/api/
 # if `None` then leaderboards won't load nor score submission
 osu_api_key: Optional[str] = '' 
 


### PR DESCRIPTION
There's a known issue where the original link will redirect you to the osu! community forums page instead of the API page. Adding the slash fixes the issue!